### PR TITLE
Do no remove whitespace inside CDATA

### DIFF
--- a/kotlin-xml-builder/src/main/kotlin/org/redundent/kotlin/xml/XmlBuilder.kt
+++ b/kotlin-xml-builder/src/main/kotlin/org/redundent/kotlin/xml/XmlBuilder.kt
@@ -54,7 +54,7 @@ class CDATAElement internal constructor(text: String) : TextElement(text) {
 		}
 
 		val lineEnding = getLineEnding(prettyFormat)
-		builder.append("$indent<![CDATA[$lineEnding$text$lineEnding]]>$lineEnding")
+		builder.append("$indent<![CDATA[$text]]>$lineEnding")
 	}
 }
 
@@ -526,7 +526,7 @@ private fun copy(source: W3CNode, dest: Node) {
 					.forEach { copy(it, cur) }
 		}
 		W3CNode.CDATA_SECTION_NODE -> {
-			dest.cdata(source.nodeValue.trim { it.isWhitespace() || it == '\r' || it == '\n' })
+			dest.cdata(source.nodeValue)
 		}
 		W3CNode.TEXT_NODE -> {
  			dest.text(source.nodeValue.trim { it.isWhitespace() || it == '\r' || it == '\n' })

--- a/kotlin-xml-builder/src/test/kotlin/org/redundent/kotlin/xml/XmlBuilderTest.kt
+++ b/kotlin-xml-builder/src/test/kotlin/org/redundent/kotlin/xml/XmlBuilderTest.kt
@@ -355,6 +355,9 @@ class XmlBuilderTest : XmlBuilderTestBase() {
 	fun parseCData() = parseTest()
 
 	@Test
+	fun parseCDataWhitespace() = parseTest()
+
+	@Test
 	fun parseCustomNamespaces() = parseTest()
 
 	@Test

--- a/kotlin-xml-builder/src/test/resources/test-results/XmlBuilderTest/cdata.xml
+++ b/kotlin-xml-builder/src/test/resources/test-results/XmlBuilderTest/cdata.xml
@@ -1,5 +1,3 @@
 <root>
-	<![CDATA[
-Some & xml
-]]>
+	<![CDATA[Some & xml]]>
 </root>

--- a/kotlin-xml-builder/src/test/resources/test-results/XmlBuilderTest/parseCDataWhitespace.xml
+++ b/kotlin-xml-builder/src/test/resources/test-results/XmlBuilderTest/parseCDataWhitespace.xml
@@ -1,0 +1,12 @@
+<root>
+	<![CDATA[
+
+
+    	    some
+free         
+		form			
+	            text	      
+	            
+
+]]>
+</root>


### PR DESCRIPTION
Character data is a list of characters that need to be taken literally, even with pretty-printing it should preserve the content exactly.

Sadly I couldn't find the part of the XML spec that clarifies this.