### PR TITLE
Fix CData nesting when rendering

### DIFF
--- a/kotlin-xml-builder/src/main/kotlin/org/redundent/kotlin/xml/XmlBuilder.kt
+++ b/kotlin-xml-builder/src/main/kotlin/org/redundent/kotlin/xml/XmlBuilder.kt
@@ -53,8 +53,16 @@ class CDATAElement internal constructor(text: String) : TextElement(text) {
 			return
 		}
 
+		fun String.escapeCData():String {
+			val cdataEnd = """]]>"""
+			val cdataStart = """<![CDATA["""
+			return this
+					// split cdataEnd into two pieces so XML parser doesn't recognize it
+					.replace(cdataEnd, """]]${cdataEnd}${cdataStart}>""")
+		}
+
 		val lineEnding = getLineEnding(prettyFormat)
-		builder.append("$indent<![CDATA[$lineEnding$text$lineEnding]]>$lineEnding")
+		builder.append("$indent<![CDATA[$lineEnding${text.escapeCData()}$lineEnding]]>$lineEnding")
 	}
 }
 

--- a/kotlin-xml-builder/src/test/kotlin/org/redundent/kotlin/xml/XmlBuilderTest.kt
+++ b/kotlin-xml-builder/src/test/kotlin/org/redundent/kotlin/xml/XmlBuilderTest.kt
@@ -104,6 +104,15 @@ class XmlBuilderTest : XmlBuilderTestBase() {
 	}
 
 	@Test
+	fun cdataNesting() {
+		val root = xml("root") {
+			cdata("<![CDATA[Some & xml]]>")
+		}
+
+		validate(root)
+	}
+
+	@Test
 	fun updateAttribute() {
 		val root = xml("root") {
 			attribute("key", "value")

--- a/kotlin-xml-builder/src/test/resources/test-results/XmlBuilderTest/cdataNesting.xml
+++ b/kotlin-xml-builder/src/test/resources/test-results/XmlBuilderTest/cdataNesting.xml
@@ -1,0 +1,5 @@
+<root>
+	<![CDATA[
+<![CDATA[Some & xml]]]]><![CDATA[>
+]]>
+</root>


### PR DESCRIPTION
`]]>` must be escaped inside CData