### PR TITLE
Fixing single line rendering of CDATA and processing instruction elements

### DIFF
--- a/kotlin-xml-builder/src/main/kotlin/org/redundent/kotlin/xml/CDATAElement.kt
+++ b/kotlin-xml-builder/src/main/kotlin/org/redundent/kotlin/xml/CDATAElement.kt
@@ -4,11 +4,7 @@ package org.redundent.kotlin.xml
  * Similar to a [TextElement] except that the inner text is wrapped inside a <![CDATA[]]> tag.
  */
 class CDATAElement internal constructor(text: String) : TextElement(text) {
-	override fun render(builder: Appendable, indent: String, printOptions: PrintOptions) {
-		if (isEmpty()) {
-			return
-		}
-
+	override fun renderedText(printOptions: PrintOptions): String {
 		fun String.escapeCData(): String {
 			val cdataEnd = "]]>"
 			val cdataStart = "<![CDATA["
@@ -17,7 +13,6 @@ class CDATAElement internal constructor(text: String) : TextElement(text) {
 					.replace(cdataEnd, "]]$cdataEnd$cdataStart>")
 		}
 
-		val lineEnding = getLineEnding(printOptions)
-		builder.append("$indent<![CDATA[${text.escapeCData()}]]>$lineEnding")
+		return "<![CDATA[${text.escapeCData()}]]>"
 	}
 }

--- a/kotlin-xml-builder/src/main/kotlin/org/redundent/kotlin/xml/ProcessingInstructionElement.kt
+++ b/kotlin-xml-builder/src/main/kotlin/org/redundent/kotlin/xml/ProcessingInstructionElement.kt
@@ -4,12 +4,6 @@ package org.redundent.kotlin.xml
  * Similar to a [TextElement] except that the inner text is wrapped inside <??> tag.
  */
 class ProcessingInstructionElement internal constructor(text: String) : TextElement(text) {
-	override fun render(builder: Appendable, indent: String, printOptions: PrintOptions) {
-		if (isEmpty()) {
-			return
-		}
-
-		val lineEnding = getLineEnding(printOptions)
-		builder.append("$indent<?$text?>$lineEnding")
-	}
+	override fun renderedText(printOptions: PrintOptions): String =
+		"<?$text?>"
 }

--- a/kotlin-xml-builder/src/main/kotlin/org/redundent/kotlin/xml/TextElement.kt
+++ b/kotlin-xml-builder/src/main/kotlin/org/redundent/kotlin/xml/TextElement.kt
@@ -15,10 +15,13 @@ open class TextElement internal constructor(val text: String) : Element {
 
 		val lineEnding = getLineEnding(printOptions)
 
-		builder.append("$indent${escapeValue(text, printOptions.xmlVersion)}$lineEnding")
+		builder.append("$indent${renderedText(printOptions)}$lineEnding")
 	}
 
 	internal fun renderSingleLine(builder: Appendable, printOptions: PrintOptions) {
-		builder.append(escapeValue(text, printOptions.xmlVersion))
+		builder.append(renderedText(printOptions))
 	}
+
+	internal open fun renderedText(printOptions: PrintOptions): String? =
+		escapeValue(text, printOptions.xmlVersion)
 }

--- a/kotlin-xml-builder/src/test/kotlin/org/redundent/kotlin/xml/XmlBuilderTest.kt
+++ b/kotlin-xml-builder/src/test/kotlin/org/redundent/kotlin/xml/XmlBuilderTest.kt
@@ -79,6 +79,28 @@ class XmlBuilderTest : XmlBuilderTestBase() {
 	}
 
 	@Test
+	fun singleLineCDATAElement() {
+		val root = xml("root") {
+			element("element") {
+				cdata("Some & xml")
+			}
+		}
+
+		validate(root, PrintOptions(pretty = true, singleLineTextElements = true))
+	}
+
+	@Test
+	fun singleLineProcessingInstructionElement() {
+		val root = xml("root") {
+			element("element") {
+				processingInstruction("SomeProcessingInstruction")
+			}
+		}
+
+		validate(root, PrintOptions(pretty = true, singleLineTextElements = true))
+	}
+
+	@Test
 	fun comment() {
 		val root = xml("root") {
 			comment("my comment -->")

--- a/kotlin-xml-builder/src/test/resources/test-results/XmlBuilderTest/singleLineCDATAElement.xml
+++ b/kotlin-xml-builder/src/test/resources/test-results/XmlBuilderTest/singleLineCDATAElement.xml
@@ -1,0 +1,3 @@
+<root>
+	<element><![CDATA[Some & xml]]></element>
+</root>

--- a/kotlin-xml-builder/src/test/resources/test-results/XmlBuilderTest/singleLineProcessingInstructionElement.xml
+++ b/kotlin-xml-builder/src/test/resources/test-results/XmlBuilderTest/singleLineProcessingInstructionElement.xml
@@ -1,0 +1,3 @@
+<root>
+	<element><?SomeProcessingInstruction?></element>
+</root>


### PR DESCRIPTION
Single line rendering of CDATA and processing instruction were missing `<![CDATA[...]]>` and `<?...?>` sequences respectively.