### PR TITLE
Suggested change to make documentation more understandable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ xml("root") {
 ```
 
 ## Print Options
-You can use the new PrintOptions class to control more of how your xml will look when rendered.
+You can now control how your xml will look when rendered by passing the new PrintOptions class as an argument to `toString`.
 
 `pretty` - This is the default and will produce the xml you see above.
 


### PR DESCRIPTION
Today, when I was trying to use the singleLineTextElements option, I had to look into the source code of the library to figure out how to use this feature in my code. 

I have updated the documentation now to make it more obvious to the reader how to actually use the different print options.