### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# https://help.github.com/articles/dealing-with-line-endings/
+# https://github.com/alexkaratarakis/gitattributes
+
+* text=auto
+
+# The above will handle all files NOT found below
+
+# Linux start script should use lf
+gradlew         text eol=lf
+*.bash          text eol=lf
+*.sh            text eol=lf
+
+# These are Windows script files and should use crlf
+*.bat             text eol=crlf
+*.cmd             text eol=crlf
+
+# Tell Git not to export certain files or directories when generating an archive.
+# Since an archive doesn't contain git data, also exclude git metadata files.
+.gitattributes export-ignore
+.gitignore     export-ignore


### PR DESCRIPTION
Add `.gitattributes` file to ensure consistent handling of line endings cross platforms, and to exclude git metadata from archives.